### PR TITLE
Fix Jam address types - coinjoin wallets are always P2WPKH

### DIFF
--- a/src/lib/data/jam.json
+++ b/src/lib/data/jam.json
@@ -33,7 +33,7 @@
     {
       "id": "address_type",
       "title": "Address Type",
-      "body": "Segwit Native (bc1), P2TR"
+      "body": "Segwit Native (bc1)"
     }
   ],
   "overview": {


### PR DESCRIPTION
Only sending to P2TR addresses is supported, same as P2PKH and P2SH.