### PR TITLE
Calculator update

### DIFF
--- a/src/routes/calculator/+page.server.ts
+++ b/src/routes/calculator/+page.server.ts
@@ -112,20 +112,20 @@ export const actions = {
 
     let standaloneTransactionInputs: number = 0;
 
-    standaloneTransactionInputs = inputsCount % 10;
+    standaloneTransactionInputs = inputsCount % 9;
 
-    let initialTransactionsWith10Inputs: number = 0;
+    let initialTransactionsWith9Inputs: number = 0;
 
-    initialTransactionsWith10Inputs = Math.floor(inputsCount / 10);
+    initialTransactionsWith9Inputs = Math.floor(inputsCount / 9);
 
     let totalNumberOfTransactions: number = 0;
 
     if (standaloneTransactionInputs === 0) {
       totalNumberOfTransactions =
-        initialTransactionsWith10Inputs * transactionQueueLength;
+        initialTransactionsWith9Inputs * transactionQueueLength;
     } else {
       totalNumberOfTransactions =
-        initialTransactionsWith10Inputs * transactionQueueLength +
+        initialTransactionsWith9Inputs * transactionQueueLength +
         transactionQueueLength;
     }
 
@@ -138,23 +138,23 @@ export const actions = {
     let numberOfInitialTransactions: number = 0;
 
     numberOfInitialTransactions =
-      Math.ceil(inputsCount / 10) * liquidityMultiplier;
+      Math.ceil(inputsCount / 9) * liquidityMultiplier;
 
-    let utxosFor10InputsTransaction: number = 0;
+    let utxosFor9InputsTransaction: number = 0;
 
-    if (initialTransactionsWith10Inputs === 0) {
-      utxosFor10InputsTransaction = 0;
+    if (initialTransactionsWith9Inputs === 0) {
+      utxosFor9InputsTransaction = 0;
     } else {
-      utxosFor10InputsTransaction = 10;
+      utxosFor9InputsTransaction = 9;
     }
 
     const vbytesPerInput: number = 69;
     const vbytesPerOutput: number = 31;
-    let totalVbytesFor10Utxos: number = 0;
+    let totalVbytesFor9Utxos: number = 0;
 
-    totalVbytesFor10Utxos =
+    totalVbytesFor9Utxos =
       (vbytesPerInput + vbytesPerOutput) *
-      utxosFor10InputsTransaction *
+      utxosFor9InputsTransaction *
       transactionQueueLength;
 
     let outputs_first_tx: number;
@@ -166,48 +166,48 @@ export const actions = {
 
     if (standaloneTransactionInputs === 0) {
       outputs_first_tx = 0;
-    } else if (standaloneTransactionInputs >= 10) {
-      outputs_first_tx = 10;
+    } else if (standaloneTransactionInputs >= 9) {
+      outputs_first_tx = 9;
     } else {
       outputs_first_tx = standaloneTransactionInputs + 1;
     }
 
     if (outputs_first_tx === 0) {
       outputs_second_tx = 0;
-    } else if (outputs_first_tx >= 10) {
-      outputs_second_tx = 10;
+    } else if (outputs_first_tx >= 9) {
+      outputs_second_tx = 9;
     } else {
       outputs_second_tx = outputs_first_tx + 1;
     }
 
     if (outputs_second_tx === 0) {
       outputs_third_tx = 0;
-    } else if (outputs_second_tx >= 10) {
-      outputs_third_tx = 10;
+    } else if (outputs_second_tx >= 9) {
+      outputs_third_tx = 9;
     } else {
       outputs_third_tx = outputs_second_tx + 1;
     }
 
     if (outputs_third_tx === 0) {
       outputs_fourth_tx = 0;
-    } else if (outputs_third_tx >= 10) {
-      outputs_fourth_tx = 10;
+    } else if (outputs_third_tx >= 9) {
+      outputs_fourth_tx = 9;
     } else {
       outputs_fourth_tx = outputs_third_tx + 1;
     }
 
     if (outputs_fourth_tx === 0) {
       outputs_fifth_tx = 0;
-    } else if (outputs_fourth_tx >= 10) {
-      outputs_fifth_tx = 10;
+    } else if (outputs_fourth_tx >= 9) {
+      outputs_fifth_tx = 9;
     } else {
       outputs_fifth_tx = outputs_fourth_tx + 1;
     }
 
     if (outputs_fifth_tx === 0) {
       outputs_sixth_tx = 0;
-    } else if (outputs_fifth_tx >= 10) {
-      outputs_sixth_tx = 10;
+    } else if (outputs_fifth_tx >= 9) {
+      outputs_sixth_tx = 9;
     } else {
       outputs_sixth_tx = outputs_fifth_tx + 1;
     }
@@ -216,13 +216,13 @@ export const actions = {
 
     if (isPrivacyLevelHigh) {
       finalNumberOfOutputs =
-        initialTransactionsWith10Inputs * 10 * outputs_sixth_tx;
+        initialTransactionsWith9Inputs * 9 * outputs_sixth_tx;
     } else if (isFirstCoinjoin) {
       finalNumberOfOutputs =
-        initialTransactionsWith10Inputs * 10 + outputs_second_tx;
+        initialTransactionsWith9Inputs * 9 + outputs_second_tx;
     } else {
       finalNumberOfOutputs =
-        initialTransactionsWith10Inputs * 10 + outputs_first_tx;
+        initialTransactionsWith9Inputs * 9 + outputs_first_tx;
     }
 
     finalNumberOfOutputs = finalNumberOfOutputs * liquidityMultiplier;
@@ -258,7 +258,7 @@ export const actions = {
     let totalVbytesForAllTransactions: number = 0;
 
     totalVbytesForAllTransactions =
-      (totalVbytesFor10Utxos * initialTransactionsWith10Inputs +
+      (totalVbytesFor9Utxos * initialTransactionsWith9Inputs +
         totalVbytesStandaloneTransaction) *
       liquidityMultiplier;
 

--- a/src/routes/calculator/+page.server.ts
+++ b/src/routes/calculator/+page.server.ts
@@ -163,9 +163,6 @@ export const actions = {
     let outputs_fourth_tx: number;
     let outputs_fifth_tx: number;
     let outputs_sixth_tx: number;
-    let outputs_seventh_tx: number;
-    let outputs_eighth_tx: number;
-    let outputs_ninth_tx: number;
 
     if (standaloneTransactionInputs === 0) {
       outputs_first_tx = 0;
@@ -215,35 +212,11 @@ export const actions = {
       outputs_sixth_tx = outputs_fifth_tx + 1;
     }
 
-    if (outputs_sixth_tx === 0) {
-      outputs_seventh_tx = 0;
-    } else if (outputs_sixth_tx >= 10) {
-      outputs_seventh_tx = 10;
-    } else {
-      outputs_seventh_tx = outputs_sixth_tx + 1;
-    }
-
-    if (outputs_seventh_tx === 0) {
-      outputs_eighth_tx = 0;
-    } else if (outputs_seventh_tx >= 10) {
-      outputs_eighth_tx = 10;
-    } else {
-      outputs_eighth_tx = outputs_seventh_tx + 1;
-    }
-
-    if (outputs_eighth_tx === 0) {
-      outputs_ninth_tx = 0;
-    } else if (outputs_eighth_tx >= 10) {
-      outputs_ninth_tx = 10;
-    } else {
-      outputs_ninth_tx = outputs_eighth_tx + 1;
-    }
-
     let finalNumberOfOutputs: number = 0;
 
     if (isPrivacyLevelHigh) {
       finalNumberOfOutputs =
-        initialTransactionsWith10Inputs * 10 * outputs_ninth_tx;
+        initialTransactionsWith10Inputs * 10 * outputs_sixth_tx;
     } else if (isFirstCoinjoin) {
       finalNumberOfOutputs =
         initialTransactionsWith10Inputs * 10 + outputs_second_tx;
@@ -265,18 +238,11 @@ export const actions = {
         vbytesPerInput * outputs_second_tx +
         vbytesPerOutput * outputs_third_tx +
         vbytesPerInput * outputs_third_tx +
-        vbytesPerInput * outputs_fourth_tx + // error?
         vbytesPerOutput * outputs_fourth_tx +
-        vbytesPerInput * outputs_fifth_tx +
+        vbytesPerInput * outputs_fourth_tx +
         vbytesPerOutput * outputs_fifth_tx +
-        vbytesPerInput * outputs_sixth_tx +
-        vbytesPerOutput * outputs_sixth_tx +
-        vbytesPerInput * outputs_seventh_tx +
-        vbytesPerOutput * outputs_seventh_tx +
-        vbytesPerInput * outputs_eighth_tx +
-        vbytesPerOutput * outputs_eighth_tx +
-        vbytesPerInput * outputs_ninth_tx +
-        vbytesPerOutput * outputs_ninth_tx;
+        vbytesPerInput * outputs_fifth_tx +
+        vbytesPerOutput * outputs_sixth_tx;
     } else if (isFirstCoinjoin) {
       totalVbytesStandaloneTransaction =
         vbytesPerInput * standaloneTransactionInputs +

--- a/src/routes/calculator/+page.svelte
+++ b/src/routes/calculator/+page.svelte
@@ -77,6 +77,10 @@
       element.scrollIntoView({ behavior: "smooth" });
     }
   }
+
+  function handleInput() {
+    btcAmount = parseFloat(event.target.value).toString();
+  }
 </script>
 
 <svelte:window bind:scrollY={y} />
@@ -113,13 +117,12 @@
       {text.calculator.how_much_bitcoin.label}
       <div>
         <input
-          type="number"
-          min="0"
-          step="0.00000001"
+          type="text"
           id="how_much_bitcoin"
           name="how_much_bitcoin"
           class="text-dark-blue text-right px-2 max-w-20"
-          bind:value={btcAmount}
+          value={btcAmount}
+          on:input={handleInput}
         />
         {text.calculator.how_much_bitcoin.btc}
       </div>
@@ -213,9 +216,9 @@
         id="mining_fees"
         name="mining_fees"
         bind:value={currentFeeRate}
-        readonly
-        class="text-dark-blue text-right px-2 hover:cursor-not-allowed"
+        class="text-dark-blue text-right px-2"
       />
+      sats/vbyte
     </label>
 
     {#if form?.errMiningFeeRate}

--- a/src/routes/calculator/+page.svelte
+++ b/src/routes/calculator/+page.svelte
@@ -114,6 +114,8 @@
       <div>
         <input
           type="number"
+          min="0"
+          step="0.00000001"
           id="how_much_bitcoin"
           name="how_much_bitcoin"
           class="text-dark-blue text-right px-2 max-w-20"
@@ -135,6 +137,7 @@
       {text.calculator.how_many_inputs.label}
       <input
         type="number"
+        min="0"
         id="how_many_inputs"
         name="how_many_inputs"
         bind:value={inputCount}

--- a/src/routes/calculator/+page.svelte
+++ b/src/routes/calculator/+page.svelte
@@ -174,28 +174,6 @@
     {/if}
 
     <label
-      id="mining_fees"
-      for="mining_fees"
-      class="border rounded-md border-green-cj p-6 flex flex-col md:flex-row items-start md:items-center gap-4 font-inconsolata text-base w-full justify-between"
-    >
-      {text.calculator.current_fee_rate}
-      <input
-        type="text"
-        id="mining_fees"
-        name="mining_fees"
-        bind:value={currentFeeRate}
-        readonly
-        class="text-dark-blue text-right px-2 hover:cursor-not-allowed"
-      />
-    </label>
-
-    {#if form?.errMiningFeeRate}
-      <div class="text-red text-sm w-full text-left">
-        {form?.errMiningFeeRate}
-      </div>
-    {/if}
-
-    <label
       id="is_first_coinjoin"
       for="is_first_coinjoin"
       class="border rounded-md border-green-cj p-6 flex flex-col md:flex-row items-start md:items-center gap-4 font-inconsolata text-base w-full justify-between"
@@ -218,6 +196,28 @@
     {#if form?.errIsFirstCoinjoin}
       <div class="text-red text-sm w-full text-left">
         {form?.errIsFirstCoinjoin}
+      </div>
+    {/if}
+
+    <label
+      id="mining_fees"
+      for="mining_fees"
+      class="border rounded-md border-green-cj p-6 flex flex-col md:flex-row items-start md:items-center gap-4 font-inconsolata text-base w-full justify-between"
+    >
+      {text.calculator.current_fee_rate}
+      <input
+        type="text"
+        id="mining_fees"
+        name="mining_fees"
+        bind:value={currentFeeRate}
+        readonly
+        class="text-dark-blue text-right px-2 hover:cursor-not-allowed"
+      />
+    </label>
+
+    {#if form?.errMiningFeeRate}
+      <div class="text-red text-sm w-full text-left">
+        {form?.errMiningFeeRate}
       </div>
     {/if}
 


### PR DESCRIPTION
this PR does 3 things:
1. reduces the number of transaction queue length to 6, because Turbolay says this is closer to the current average real results.
2. reduces the number of inputs and outputs to 9.
3. inverts the order of the current fee rate box, with the is this your first coinjoin box, because the current fee rate is the only one with default values, and doesn't require user input.

this fixes the following issues:
https://github.com/CoinjoinsOrg/coinjoins/issues/61
https://github.com/CoinjoinsOrg/coinjoins/issues/60